### PR TITLE
Also update labels

### DIFF
--- a/background.js
+++ b/background.js
@@ -8,6 +8,14 @@ chrome.tabs.onUpdated.addListener(function() {
             var labels = document.getElementsByClassName("card-label");
 
             for (var i = 0, len = labels.length, color; i < len; i++) {
+              if (labels[i].title.indexOf("#") === 0 && labels[i].title.indexOf(":") > 0) {
+                color = labels[i].title.split(":")[0];
+                labels[i].style.backgroundColor = color;
+
+                labels[i].title = labels[i].title.substring(color.length + 1);
+              }
+
+
               if (labels[i].innerText.indexOf("#") === 0 && labels[i].innerText.indexOf(":") > 0) {
                 color = labels[i].innerText.split(":")[0];
                 labels[i].style.backgroundColor = color;

--- a/background.js
+++ b/background.js
@@ -19,7 +19,7 @@ chrome.tabs.onUpdated.addListener(function() {
                     }
                   }        
                 }
-              }, 5000);
+              }, 0);
 
 		`
 	      });

--- a/background.js
+++ b/background.js
@@ -1,31 +1,28 @@
 
 chrome.tabs.onUpdated.addListener(function() {
     chrome.tabs.query({"active": true, "lastFocusedWindow": true}, function(tabs) {
-      chrome.tabs.executeScript(tabs[0].id, {
-        "code": `
+      if (tabs[0].title.indexOf("Trello") !== -1) {
+	      chrome.tabs.executeScript(tabs[0].id, {
+            "code": `
 
-          setInterval(function() {
-            var labels = document.getElementsByClassName("card-label");
+              setInterval(function() {
+                var labels = document.querySelectorAll(".card-label[title*='#']");
 
-            for (var i = 0, len = labels.length, color; i < len; i++) {
-              if (labels[i].title.indexOf("#") === 0 && labels[i].title.indexOf(":") > 0) {
-                color = labels[i].title.split(":")[0];
-                labels[i].style.backgroundColor = color;
+                for (var i = 0, len = labels.length, color; i < len; i++) {
+                  if (labels[i].title.indexOf(":") > 0) {
+                    color = labels[i].title.split(":")[0];
+                    labels[i].style.backgroundColor = color;
 
-                labels[i].title = labels[i].title.substring(color.length + 1);
-              }
+                    labels[i].title = labels[i].title.substring(color.length + 1);
+                    if (labels[i].innerText != "") {
+                        labels[i].innerText = labels[i].innerText.substring(color.length + 1);                
+                    }
+                  }        
+                }
+              }, 5000);
 
-
-              if (labels[i].innerText.indexOf("#") === 0 && labels[i].innerText.indexOf(":") > 0) {
-                color = labels[i].innerText.split(":")[0];
-                labels[i].style.backgroundColor = color;
-
-                labels[i].innerText = labels[i].innerText.substring(color.length + 1);
-              }
-            }
-          }, 0);
-
-        `
-      });
+		`
+	      });
+      }
     });
 });


### PR DESCRIPTION
Allows colours to work in un-expanded mode.

By also checking/updating the titles, a user can pick any colour for their label (so that it shows up in the overall view), and then we can update the background colour on that view as well:

example:

![image](https://user-images.githubusercontent.com/10179637/96561136-14127080-12b7-11eb-96c6-f72ef5ee2ec4.png)
